### PR TITLE
Spanish description to books_descriptions script

### DIFF
--- a/books_descriptions/generate_add_missing_description_cmd.js
+++ b/books_descriptions/generate_add_missing_description_cmd.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 
 const descriptionBase = {
   en: 'book by',
+  es: 'libro de',
   fr: 'livre de',
   de: 'Buch von'
 }


### PR DESCRIPTION
Hi @maxlath!

Nice to know that you have developed this easy-way to translate from the Netherlands the descriptions to our own languages. In my case, I know Spanish and a bit Portuguese, but maybe @Santamarcanda could know more how is the best form to translate this string, because she is native speaker.

I read the README of the script and I checked that you run it with wikidata-cli. I don't know if you are automating this task with some bot. If not, I could help you with that using CanaryBot. I can execute for a long time. As this script doesn't replace the description if it exists, I think it could be secure to make with a bot, because it would change only the inexistent descriptions. If you prefer to discuss this topic in another place, send me a email!

What do you think? Of course, thanks in advance for this great script, Maxime!

Regards,
Iván